### PR TITLE
Fixes issue with using multiple params and columns

### DIFF
--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
     "eslint-config-recommended": "^1.5.0",
     "eslint-config-standard": "^10.2.1",
     "eslint-loader": "^1.9.0",
-    "eslint-plugin-import": "^2.7.0",
+    "eslint-plugin-import": "^2.16.0",
     "eslint-plugin-node": "^5.2.0",
     "eslint-plugin-promise": "^3.5.0",
     "eslint-plugin-standard": "^3.0.1",

--- a/src/CellHtml/widget/CellHtml.js
+++ b/src/CellHtml/widget/CellHtml.js
@@ -68,7 +68,10 @@ export default defineWidget('CellHtml', false, {
 
         if (html) {
             for (param of this.params) {
-                htmlStr = html.split("${" + param.name + "}").join(rowObj.get(param.valueAttr));
+                if (-1 !== html.indexOf("${" + param.name + "}")) {
+                    htmlStr = html.split("${" + param.name + "}").join(rowObj.get(param.valueAttr));
+                    break;
+                }
             }
             const nodeToRemove = query("." + column.columnName + "-html", nodeToApply)[ 0 ];
             if (nodeToRemove) {


### PR DESCRIPTION
When using this widget I found that if I had more than one column that needed to get HTML from an underlying entity attribute (so I had two parameters and two columns getting values from those parameters), then only the last parameter was used. Other parameters would be ignored and the parameter reference (eg. ${myattribute}) would be displayed in the column instead of the HTML attribute value.
In this pull request I have modified the loop that processes the params to exit once a param value has been used to replace the column value.
I don't know if the intention was to be able to replace multiple params in the Html to apply for a column - if so this change will not do that, but that was also not working prior to this change.